### PR TITLE
Handle async method inside the EnrichingHandler correctly

### DIFF
--- a/src/Fabrik.Common.WebAPI/EnrichingHandler.cs
+++ b/src/Fabrik.Common.WebAPI/EnrichingHandler.cs
@@ -7,17 +7,13 @@ namespace Fabrik.Common.WebAPI
 {
     public class EnrichingHandler : DelegatingHandler
     {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return base.SendAsync(request, cancellationToken)
-                .ContinueWith(task =>
-                {
-                    var response = task.Result;
-                    var enrichers = request.GetConfiguration().GetResponseEnrichers();
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+            var enrichers = request.GetConfiguration().GetResponseEnrichers();
 
-                    return enrichers.Where(e => e.CanEnrich(response))
-                        .Aggregate(response, (resp, enricher) => enricher.Enrich(response));
-                });
+            return enrichers.Where(e => e.CanEnrich(response))
+                .Aggregate(response, (resp, enricher) => enricher.Enrich(response));
         }
     }
 }


### PR DESCRIPTION
With this commit, the async method inside the EnrichingHandler is handled correctly as there were multiple problems such as scheduling the continuation even if the task is already completed and without checking its status, etc. As the project is on .NET 4.5, there's no reason not to use async/await keywords.
