### PR TITLE
Updated AtomExtensions to create XmlSyndicationContent when ContentType is set to "xml"

### DIFF
--- a/src/Fabrik.Common.WebAPI/AtomPub/AtomExtensions.cs
+++ b/src/Fabrik.Common.WebAPI/AtomPub/AtomExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.ServiceModel.Syndication;
+using System.Xml;
 
 namespace Fabrik.Common.WebAPI.AtomPub
 {
@@ -66,12 +67,34 @@ namespace Fabrik.Common.WebAPI.AtomPub
             command.PublishDate = GetPublishDate(item.PublishDate);
         }
 
-        private static SyndicationContent GetSyndicationContent(string content, string contentType)
+        private static SyndicationContent GetSyndicationContent(object content, string contentType)
         {
-            if (content.IsNullOrEmpty() || contentType.ToLowerInvariant() == PublicationContentTypes.Text)
-                return SyndicationContent.CreatePlaintextContent(content ?? string.Empty);
-
-            return SyndicationContent.CreateHtmlContent(content);
+            if (contentType.ToLowerInvariant() == PublicationContentTypes.Text)
+            {
+                return SyndicationContent.CreatePlaintextContent((string) content ?? string.Empty);
+            }
+            
+            if (contentType.ToLowerInvariant() == PublicationContentTypes.HTML)
+            {
+                return SyndicationContent.CreateHtmlContent((string) content ?? string.Empty);
+            }
+            
+            if (contentType.ToLowerInvariant() == PublicationContentTypes.XHTML)
+            {
+                return SyndicationContent.CreateXhtmlContent((string) content ?? string.Empty);                                
+            }
+            
+            if (contentType.ToLowerInvariant() == PublicationContentTypes.XML)
+            {
+                return SyndicationContent.CreateXmlContent(content);                
+            }
+            
+            if (content is string && ((string) content).IsNullOrEmpty())
+            {
+                return SyndicationContent.CreatePlaintextContent(string.Empty);
+            }
+            
+            return SyndicationContent.CreateHtmlContent(content.ToString());
         }
 
         public static DateTime GetPublishDate(DateTimeOffset syndicationDate)

--- a/src/Fabrik.Common.WebAPI/AtomPub/IPublication.cs
+++ b/src/Fabrik.Common.WebAPI/AtomPub/IPublication.cs
@@ -27,10 +27,10 @@ namespace Fabrik.Common.WebAPI.AtomPub
         /// <summary>
         /// The content of the publication.
         /// </summary>
-        string Content { get; }
+        object Content { get; }
 
         /// <summary>
-        /// The type of content. Either "text", "html", "xhtml" or a valid MIME media type.
+        /// The type of content. Either "text", "html", "xhtml", "xml" or a valid MIME media type.
         /// </summary>
         string ContentType { get; }
         

--- a/src/Fabrik.Common.WebAPI/AtomPub/PublicationContentTypes.cs
+++ b/src/Fabrik.Common.WebAPI/AtomPub/PublicationContentTypes.cs
@@ -5,5 +5,7 @@ namespace Fabrik.Common.WebAPI.AtomPub
     {
         public const string Text = "text";
         public const string HTML = "html";
+        public const string XHTML = "xhtml";
+        public const string XML = "xml";
     }
 }


### PR DESCRIPTION
Sharing the changes I had to make to support my use case: having content type="text/xml" in feed entry content.  Current code supports only plain text and html.  I updated AtomExtensions to create XmlSyndicationContent when ContentType is set to "xml".  Just sharing my changes - I'm not requesting a merge in right now as the changes were made only on the feed generation side and not for create/update operations.  Also, made a breaking change - IPublication.Content changed from string to object which could be handled more elegantly.
