### PR TITLE
Readfully stream extension optimization

### DIFF
--- a/src/Fabrik.Common/IOExtensions.cs
+++ b/src/Fabrik.Common/IOExtensions.cs
@@ -16,6 +16,9 @@ namespace Fabrik.Common
         {
             Ensure.Argument.NotNull(stream, "stream");
             
+            if (stream is Memory)
+                return (stream as Memory).ToArray();
+            
             using (var ms = new MemoryStream())
             {
                 stream.CopyTo(ms);


### PR DESCRIPTION
Use check if stream is already a `MemoryStream`
