### PR TITLE
Fixed null check order for DecompressionHandler

### DIFF
--- a/src/Fabrik.Common.WebAPI/DecompressionHandler.cs
+++ b/src/Fabrik.Common.WebAPI/DecompressionHandler.cs
@@ -22,7 +22,7 @@ namespace Fabrik.Common.WebAPI
         {
             var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            if (response.Content.Headers.ContentEncoding.IsNotNullOrEmpty() && response.Content != null)
+            if (response.Content != null && response.Content.Headers.ContentEncoding.IsNotNullOrEmpty())
             {
                 var encoding = response.Content.Headers.ContentEncoding.First();
 


### PR DESCRIPTION
DecompressionHandler had the null check after checking for Headers for ContentEncoding which would result in a `NullReferenceException`. Just inverting those checks.
